### PR TITLE
Add slow queries class

### DIFF
--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -183,4 +183,8 @@ class SlowQueries {
 
 		return false;
 	}
+
+	public function log_sql_queries() {
+		swpd_log( $this->debugger_name, $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
+	}
 }

--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -188,7 +188,7 @@ class SlowQueries {
 		swpd_log( $this->debugger_name, $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
 	}
 
-	public function get_post_id() {
+	private function get_post_id() {
 		if ( isset( $_GET['post'] ) ) {
 			$post_id = (int) $_GET['post'];
 		} elseif ( isset( $_POST['post_ID'] ) ) {

--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -187,4 +187,15 @@ class SlowQueries {
 	public function log() {
 		swpd_log( $this->debugger_name, $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
 	}
+
+	public function get_post_id() {
+		if ( isset( $_GET['post'] ) ) {
+			$post_id = $post_ID = (int) $_GET['post'];
+		} elseif ( isset( $_POST['post_ID'] ) ) {
+			$post_id = $post_ID = (int) $_POST['post_ID'];
+		} else {
+			$post_id = $post_ID = 0;
+		}
+		return $post_id;
+	}
 }

--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -121,69 +121,7 @@ class SlowQueries {
 
 		return $out;
 	}
-
-	/**
-	 * This is a copy of core's wpdb::get_table_from_query which is protected and can't otherwise be used
-	 *
-	 * @see https://core.trac.wordpress.org/browser/tags/4.7/src/wp-includes/wp-db.php#L3022
-	 */
-	public function get_table_from_query( $query ) {
-		// Remove characters that can legally trail the table name.
-		$query = rtrim( $query, ';/-#' );
-
-		// Allow (select...) union [...] style queries. Use the first query's table name.
-		$query = ltrim( $query, "\r\n\t (" );
-
-		// Strip everything between parentheses except nested selects.
-		$query = preg_replace( '/\((?!\s*select)[^(]*?\)/is', '()', $query );
-
-		// Quickly match most common queries.
-		if ( preg_match( '/^\s*(?:'
-		                 . 'SELECT.*?\s+FROM'
-		                 . '|INSERT(?:\s+LOW_PRIORITY|\s+DELAYED|\s+HIGH_PRIORITY)?(?:\s+IGNORE)?(?:\s+INTO)?'
-		                 . '|REPLACE(?:\s+LOW_PRIORITY|\s+DELAYED)?(?:\s+INTO)?'
-		                 . '|UPDATE(?:\s+LOW_PRIORITY)?(?:\s+IGNORE)?'
-		                 . '|DELETE(?:\s+LOW_PRIORITY|\s+QUICK|\s+IGNORE)*(?:.+?FROM)?'
-		                 . ')\s+((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)/is', $query, $maybe ) ) {
-			return str_replace( '`', '', $maybe[1] );
-		}
-
-		// SHOW TABLE STATUS and SHOW TABLES WHERE Name = 'wp_posts'
-		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES).+WHERE\s+Name\s*=\s*("|\')((?:[0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)\\1/is', $query, $maybe ) ) {
-			return $maybe[2];
-		}
-
-		// SHOW TABLE STATUS LIKE and SHOW TABLES LIKE 'wp\_123\_%'
-		// This quoted LIKE operand seldom holds a full table name.
-		// It is usually a pattern for matching a prefix so we just
-		// strip the trailing % and unescape the _ to get 'wp_123_'
-		// which drop-ins can use for routing these SQL statements.
-		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES)\s+(?:WHERE\s+Name\s+)?LIKE\s*("|\')((?:[\\\\0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)%?\\1/is', $query, $maybe ) ) {
-			return str_replace( '\\_', '_', $maybe[2] );
-		}
-
-		// Big pattern for the rest of the table-related queries.
-		if ( preg_match( '/^\s*(?:'
-		                 . '(?:EXPLAIN\s+(?:EXTENDED\s+)?)?SELECT.*?\s+FROM'
-		                 . '|DESCRIBE|DESC|EXPLAIN|HANDLER'
-		                 . '|(?:LOCK|UNLOCK)\s+TABLE(?:S)?'
-		                 . '|(?:RENAME|OPTIMIZE|BACKUP|RESTORE|CHECK|CHECKSUM|ANALYZE|REPAIR).*\s+TABLE'
-		                 . '|TRUNCATE(?:\s+TABLE)?'
-		                 . '|CREATE(?:\s+TEMPORARY)?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?'
-		                 . '|ALTER(?:\s+IGNORE)?\s+TABLE'
-		                 . '|DROP\s+TABLE(?:\s+IF\s+EXISTS)?'
-		                 . '|CREATE(?:\s+\w+)?\s+INDEX.*\s+ON'
-		                 . '|DROP\s+INDEX.*\s+ON'
-		                 . '|LOAD\s+DATA.*INFILE.*INTO\s+TABLE'
-		                 . '|(?:GRANT|REVOKE).*ON\s+TABLE'
-		                 . '|SHOW\s+(?:.*FROM|.*TABLE)'
-		                 . ')\s+\(*\s*((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)\s*\)*/is', $query, $maybe ) ) {
-			return str_replace( '`', '', $maybe[1] );
-		}
-
-		return false;
-	}
-
+	
 	public function log() {
 		swpd_log( $this->debugger_name, $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
 	}

--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -190,11 +190,11 @@ class SlowQueries {
 
 	public function get_post_id() {
 		if ( isset( $_GET['post'] ) ) {
-			$post_id = $post_ID = (int) $_GET['post'];
+			$post_id = (int) $_GET['post'];
 		} elseif ( isset( $_POST['post_ID'] ) ) {
-			$post_id = $post_ID = (int) $_POST['post_ID'];
+			$post_id = (int) $_POST['post_ID'];
 		} else {
-			$post_id = $post_ID = 0;
+			$post_id = 0;
 		}
 		return $post_id;
 	}

--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -184,7 +184,7 @@ class SlowQueries {
 		return false;
 	}
 
-	public function log_sql_queries() {
+	public function log() {
 		swpd_log( $this->debugger_name, $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
 	}
 }

--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -1,0 +1,186 @@
+<?php
+
+class SlowQueries {
+
+	public function render_sql_query_summary() {
+		global $wpdb;
+		$query_types = array();
+		$query_type_counts = array();
+		if ( is_array($wpdb->queries) ) {
+			$count = count($wpdb->queries);
+			for ( $i = 0; $i < $count; ++$i ) {
+				$query = array_key_exists( 'query', $wpdb->queries[$i] ) ? $wpdb->queries[$i]['query'] : $wpdb->queries[$i][0];
+				$query = trim( preg_replace( '#connection: dbh_.+$#','', $query ) );
+				$query = preg_replace( "#\s+#", ' ', $query );
+				$query = str_replace( '\"', '', $query );
+				$query = str_replace( "\'", '', $query );
+				$query = preg_replace( '#wp_\d+_#', 'wp_?_', $query );
+				$query = preg_replace( "#'[^']*'#", "'?'", $query );
+				$query = preg_replace( '#"[^"]*"#', "'?'", $query );
+				$query = preg_replace( "#in ?\([^)]*\)#i", 'in(?)', $query);
+				$query = preg_replace( "#= ?\d+ ?#", "= ? ", $query );
+				$query = preg_replace( "#\d+(, ?)?#", '?\1', $query);
+				$query = preg_replace( "#/\*.*\*/$#", '', $query );
+
+				$query = preg_replace( "#\s+#", ' ', $query );
+				if ( !isset( $query_types[$query] ) )
+					$query_types[$query] = 0;
+				if ( !isset( $query_type_counts[$query] ) )
+					$query_type_counts[$query] = 0;
+				$query_type_counts[$query]++;
+				$query_types[$query] += array_key_exists( 'elapsed', $wpdb->queries[$i] ) ? $wpdb->queries[$i]['elapsed'] : $wpdb->queries[$i][1];
+			}
+		}
+
+		arsort( $query_types );
+		$out = '';
+		$count = 0;
+		$max_time_len = 0;
+		foreach( $query_types as $q => $t ) {
+			$count++;
+			$max_time_len = max($max_time_len, strlen(sprintf('%0.2f', $t * 1000)));
+			$out .= sprintf(
+				"%s queries for %sms » %s\r\n",
+				str_pad( $query_type_counts[$q], 5, ' ', STR_PAD_LEFT ),
+				str_pad( sprintf('%0.2f', $t * 1000), $max_time_len, ' ', STR_PAD_LEFT ),
+				$q
+			);
+		}
+		return $out;
+	}
+
+	public function render_sql_queries() {
+		global $wpdb, $wp_object_cache, $timestart;
+
+		$out = '';
+		$total_time = 0;
+
+		if ( !empty($wpdb->queries) ) {
+
+			$counter = 0;
+
+			foreach ( $wpdb->queries as $q ) {
+				unset($query, $elapsed, $affected_rows, $host, $microtime, $debug, $dbhname, $dataset, $callback_result, $connection);
+				extract($q);
+
+				if ( false === isset( $query ) ) {
+					$query = $q[0];
+				}
+				if ( false === isset( $elapsed ) ){
+					$elapsed = $q[1];
+				}
+				if ( false === isset( $debug ) ) {
+					$debug = $q[2];
+				}
+
+				$total_time += $elapsed;
+				if ( ++$counter > 500 ) {
+					continue;
+				}
+
+				// ts is the absolute time at which each query was executed
+				if ( true === isset( $microtime ) ) {
+					$ts = explode( ' ', $microtime );
+					$ts = $ts[0] + $ts[1];
+				} else {
+					$ts = 0;
+				}
+
+				$query = esc_html($query);
+
+				// $dbhname, $host, $port, $name, $tcp, $elapsed
+				if ( isset($connection['elapsed']) ) {
+					$connected = "Connected {$connection['dbhname']} to {$connection['host']}:{$connection['port']} ({$connection['name']}) in ".sprintf('%0.2f', 1000*$connection['elapsed'])."ms";
+				} else if ( true === isset( $connection ) ) {
+					$connected = "Reused connection to {$connection['dbhname']} ({$connection['name']})";
+				} else {
+					$connected = '';
+				}
+
+				$debug = wp_strip_all_tags( $debug );
+				$out .= "$query \n $connected $debug #{$counter} (" . number_format(sprintf('%0.1f', $elapsed * 1000), 1, '.', ',') . "ms @ " . sprintf( '%0.2f', 1000 * ( $ts - $timestart ) ) . "ms)\n\n";
+			}
+		}
+
+		$num_queries = '';
+		if ( $wpdb->num_queries ) {
+			$num_queries = 'Total Queries:' . number_format( $wpdb->num_queries ) . " | ";
+		}
+		$query_time = 'Total query time:' . number_format(sprintf('%0.1f', $total_time * 1000), 1) . "ms | ";
+		$memory_usage = 'Peak Memory Used:' . number_format( memory_get_peak_usage( ) ) . " bytes | ";
+		if ( true === property_exists( $wp_object_cache, 'time_total' ) ) {
+			$memcache_time = 'Total memcache query time:' .
+			                 number_format( sprintf( '%0.1f', $wp_object_cache->time_total * 1000 ), 1, '.', ',' ) . "ms \n\n";
+		} else {
+			$memcache_time = '';
+		}
+
+		$out = $num_queries . $query_time . $memory_usage . $memcache_time . $out;
+
+		$out = apply_filters( 'swpdb-render-sql-queries-output', $out );
+
+		return $out;
+	}
+
+	/**
+	 * This is a copy of core's wpdb::get_table_from_query which is protected and can't otherwise be used
+	 *
+	 * @see https://core.trac.wordpress.org/browser/tags/4.7/src/wp-includes/wp-db.php#L3022
+	 */
+	public function get_table_from_query( $query ) {
+		// Remove characters that can legally trail the table name.
+		$query = rtrim( $query, ';/-#' );
+
+		// Allow (select...) union [...] style queries. Use the first query's table name.
+		$query = ltrim( $query, "\r\n\t (" );
+
+		// Strip everything between parentheses except nested selects.
+		$query = preg_replace( '/\((?!\s*select)[^(]*?\)/is', '()', $query );
+
+		// Quickly match most common queries.
+		if ( preg_match( '/^\s*(?:'
+		                 . 'SELECT.*?\s+FROM'
+		                 . '|INSERT(?:\s+LOW_PRIORITY|\s+DELAYED|\s+HIGH_PRIORITY)?(?:\s+IGNORE)?(?:\s+INTO)?'
+		                 . '|REPLACE(?:\s+LOW_PRIORITY|\s+DELAYED)?(?:\s+INTO)?'
+		                 . '|UPDATE(?:\s+LOW_PRIORITY)?(?:\s+IGNORE)?'
+		                 . '|DELETE(?:\s+LOW_PRIORITY|\s+QUICK|\s+IGNORE)*(?:.+?FROM)?'
+		                 . ')\s+((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)/is', $query, $maybe ) ) {
+			return str_replace( '`', '', $maybe[1] );
+		}
+
+		// SHOW TABLE STATUS and SHOW TABLES WHERE Name = 'wp_posts'
+		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES).+WHERE\s+Name\s*=\s*("|\')((?:[0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)\\1/is', $query, $maybe ) ) {
+			return $maybe[2];
+		}
+
+		// SHOW TABLE STATUS LIKE and SHOW TABLES LIKE 'wp\_123\_%'
+		// This quoted LIKE operand seldom holds a full table name.
+		// It is usually a pattern for matching a prefix so we just
+		// strip the trailing % and unescape the _ to get 'wp_123_'
+		// which drop-ins can use for routing these SQL statements.
+		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES)\s+(?:WHERE\s+Name\s+)?LIKE\s*("|\')((?:[\\\\0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)%?\\1/is', $query, $maybe ) ) {
+			return str_replace( '\\_', '_', $maybe[2] );
+		}
+
+		// Big pattern for the rest of the table-related queries.
+		if ( preg_match( '/^\s*(?:'
+		                 . '(?:EXPLAIN\s+(?:EXTENDED\s+)?)?SELECT.*?\s+FROM'
+		                 . '|DESCRIBE|DESC|EXPLAIN|HANDLER'
+		                 . '|(?:LOCK|UNLOCK)\s+TABLE(?:S)?'
+		                 . '|(?:RENAME|OPTIMIZE|BACKUP|RESTORE|CHECK|CHECKSUM|ANALYZE|REPAIR).*\s+TABLE'
+		                 . '|TRUNCATE(?:\s+TABLE)?'
+		                 . '|CREATE(?:\s+TEMPORARY)?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?'
+		                 . '|ALTER(?:\s+IGNORE)?\s+TABLE'
+		                 . '|DROP\s+TABLE(?:\s+IF\s+EXISTS)?'
+		                 . '|CREATE(?:\s+\w+)?\s+INDEX.*\s+ON'
+		                 . '|DROP\s+INDEX.*\s+ON'
+		                 . '|LOAD\s+DATA.*INFILE.*INTO\s+TABLE'
+		                 . '|(?:GRANT|REVOKE).*ON\s+TABLE'
+		                 . '|SHOW\s+(?:.*FROM|.*TABLE)'
+		                 . ')\s+\(*\s*((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)\s*\)*/is', $query, $maybe ) ) {
+			return str_replace( '`', '', $maybe[1] );
+		}
+
+		return false;
+	}
+}

--- a/SlowQueries.php
+++ b/SlowQueries.php
@@ -121,9 +121,13 @@ class SlowQueries {
 
 		return $out;
 	}
-	
+
 	public function log() {
-		swpd_log( $this->debugger_name, $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
+		swpd_log( $this->debugger_name, $this->get_message(), null, array( 'Post' => $this->get_post_id() ), false );
+	}
+
+	private function get_message() {
+		return $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary();
 	}
 
 	private function get_post_id() {

--- a/sandbox-wp-debugger.php
+++ b/sandbox-wp-debugger.php
@@ -29,6 +29,7 @@ if ( true === defined( 'WP_CLI' ) && WP_CLI ) {
 	}
 }
 
+require_once( SWPD_DIR_PATH . 'SlowQueries.php' );
 require_once( SWPD_DIR_PATH . 'slow-post-save.php' );
 require_once( SWPD_DIR_PATH . 'slow-bulk-update.php' );
 require_once( SWPD_DIR_PATH . 'debugbar-rest-api.php' );

--- a/slow-bulk-update.php
+++ b/slow-bulk-update.php
@@ -28,17 +28,6 @@ class SWPD_Slow_Bulk_Update extends SlowQueries {
 		}
 		return $location;
 	}
-
-	public function get_post_id() {
-		if ( isset( $_GET['post'] ) ) {
-			$post_id = $post_ID = (int) $_GET['post'];
-		} elseif ( isset( $_POST['post_ID'] ) ) {
-			$post_id = $post_ID = (int) $_POST['post_ID'];
-		} else {
-			$post_id = $post_ID = 0;
-		}
-		return $post_id;
-	}
 }
 
 new SWPD_Slow_Bulk_Update();

--- a/slow-bulk-update.php
+++ b/slow-bulk-update.php
@@ -24,7 +24,7 @@ class SWPD_Slow_Bulk_Update extends SlowQueries {
 
 	public function wp_redirect_filter( $location ) {
 		if ( true === $this->is_post_save() ) {
-			$this->log_sql_queries();
+			$this->log();
 		}
 		return $location;
 	}

--- a/slow-bulk-update.php
+++ b/slow-bulk-update.php
@@ -1,6 +1,6 @@
 <?php
 
-class SWPD_Slow_Bulk_Update {
+class SWPD_Slow_Bulk_Update extends SlowQueries {
 
 	public function __construct() {
 		if ( false === defined( 'SAVEQUERIES' ) ) {
@@ -27,126 +27,6 @@ class SWPD_Slow_Bulk_Update {
 		return $location;
 	}
 
-	public function render_sql_query_summary() {
-		global $wpdb;
-		$query_types = array();
-		$query_type_counts = array();
-		if ( is_array($wpdb->queries) ) {
-			$count = count($wpdb->queries);
-			for ( $i = 0; $i < $count; ++$i ) {
-				$query = array_key_exists( 'query', $wpdb->queries[$i] ) ? $wpdb->queries[$i]['query'] : $wpdb->queries[$i][0];
-				$query = trim( preg_replace( '#connection: dbh_.+$#','', $query ) );
-				$query = preg_replace( "#\s+#", ' ', $query );
-				$query = str_replace( '\"', '', $query );
-				$query = str_replace( "\'", '', $query );
-				$query = preg_replace( '#wp_\d+_#', 'wp_?_', $query );
-				$query = preg_replace( "#'[^']*'#", "'?'", $query );
-				$query = preg_replace( '#"[^"]*"#', "'?'", $query );
-				$query = preg_replace( "#in ?\([^)]*\)#i", 'in(?)', $query);
-				$query = preg_replace( "#= ?\d+ ?#", "= ? ", $query );
-				$query = preg_replace( "#\d+(, ?)?#", '?\1', $query);
-				$query = preg_replace( "#/\*.*\*/$#", '', $query );
-
-				$query = preg_replace( "#\s+#", ' ', $query );
-				if ( !isset( $query_types[$query] ) )
-					$query_types[$query] = 0;
-				if ( !isset( $query_type_counts[$query] ) )
-					$query_type_counts[$query] = 0;
-				$query_type_counts[$query]++;
-				$query_types[$query] += array_key_exists( 'elapsed', $wpdb->queries[$i] ) ? $wpdb->queries[$i]['elapsed'] : $wpdb->queries[$i][1];
-			}
-		}
-
-		arsort( $query_types );
-		$out = '';
-		$count = 0;
-		$max_time_len = 0;
-		foreach( $query_types as $q => $t ) {
-			$count++;
-			$max_time_len = max($max_time_len, strlen(sprintf('%0.2f', $t * 1000)));
-			$out .= sprintf(
-				"%s queries for %sms » %s\r\n",
-				str_pad( $query_type_counts[$q], 5, ' ', STR_PAD_LEFT ),
-				str_pad( sprintf('%0.2f', $t * 1000), $max_time_len, ' ', STR_PAD_LEFT ),
-				$q
-			);
-		}
-		return $out;
-	}
-
-	public function render_sql_queries() {
-		global $wpdb, $wp_object_cache, $timestart;
-
-		$out = '';
-		$total_time = 0;
-
-		if ( !empty($wpdb->queries) ) {
-
-			$counter = 0;
-
-			foreach ( $wpdb->queries as $q ) {
-				unset($query, $elapsed, $affected_rows, $host, $microtime, $debug, $dbhname, $dataset, $callback_result, $connection);
-				extract($q);
-
-				if ( false === isset( $query ) ) {
-					$query = $q[0];
-				}
-				if ( false === isset( $elapsed ) ){
-					$elapsed = $q[1];
-				}
-				if ( false === isset( $debug ) ) {
-					$debug = $q[2];
-				}
-
-				$total_time += $elapsed;
-				if ( ++$counter > 500 ) {
-					continue;
-				}
-
-				// ts is the absolute time at which each query was executed
-				if ( true === isset( $microtime ) ) {
-					$ts = explode( ' ', $microtime );
-					$ts = $ts[0] + $ts[1];
-				} else {
-					$ts = 0;
-				}
-
-				$query = esc_html($query);
-
-				// $dbhname, $host, $port, $name, $tcp, $elapsed
-				if ( isset($connection['elapsed']) ) {
-					$connected = "Connected {$connection['dbhname']} to {$connection['host']}:{$connection['port']} ({$connection['name']}) in ".sprintf('%0.2f', 1000*$connection['elapsed'])."ms";
-				} else if ( true === isset( $connection ) ) {
-					$connected = "Reused connection to {$connection['dbhname']} ({$connection['name']})";
-				} else {
-					$connected = '';
-				}
-
-				$debug = wp_strip_all_tags( $debug );
-				$out .= "$query \n $connected $debug #{$counter} (" . number_format(sprintf('%0.1f', $elapsed * 1000), 1, '.', ',') . "ms @ " . sprintf( '%0.2f', 1000 * ( $ts - $timestart ) ) . "ms)\n\n";
-			}
-		}
-
-		$num_queries = '';
-	    if ( $wpdb->num_queries ) {
-            $num_queries = 'Total Queries:' . number_format( $wpdb->num_queries ) . " | ";
-		}
-		$query_time = 'Total query time:' . number_format(sprintf('%0.1f', $total_time * 1000), 1) . "ms | ";
-		$memory_usage = 'Peak Memory Used:' . number_format( memory_get_peak_usage( ) ) . " bytes | ";
-		if ( true === property_exists( $wp_object_cache, 'time_total' ) ) {
-			$memcache_time = 'Total memcache query time:' .
-				number_format( sprintf( '%0.1f', $wp_object_cache->time_total * 1000 ), 1, '.', ',' ) . "ms \n\n";
-		} else {
-			$memcache_time = '';
-		}
-
-		$out = $num_queries . $query_time . $memory_usage . $memcache_time . $out;
-
-		$out = apply_filters( 'swpdb-render-sql-queries-output', $out );
-
-		return $out;
-	}
-
 	public function get_post_id() {
 		if ( isset( $_GET['post'] ) ) {
 			$post_id = $post_ID = (int) $_GET['post'];
@@ -160,68 +40,6 @@ class SWPD_Slow_Bulk_Update {
 
 	public function log_sql_queries() {
 		swpd_log( 'slow bulk update', $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
-	}
-
-	/**
-	 * This is a copy of core's wpdb::get_table_from_query which is protected and can't otherwise be used
-	 *
-	 * @see https://core.trac.wordpress.org/browser/tags/4.7/src/wp-includes/wp-db.php#L3022
-	 */
-	public function get_table_from_query( $query ) {
-		// Remove characters that can legally trail the table name.
-		$query = rtrim( $query, ';/-#' );
-
-		// Allow (select...) union [...] style queries. Use the first query's table name.
-		$query = ltrim( $query, "\r\n\t (" );
-
-		// Strip everything between parentheses except nested selects.
-		$query = preg_replace( '/\((?!\s*select)[^(]*?\)/is', '()', $query );
-
-		// Quickly match most common queries.
-		if ( preg_match( '/^\s*(?:'
-				. 'SELECT.*?\s+FROM'
-				. '|INSERT(?:\s+LOW_PRIORITY|\s+DELAYED|\s+HIGH_PRIORITY)?(?:\s+IGNORE)?(?:\s+INTO)?'
-				. '|REPLACE(?:\s+LOW_PRIORITY|\s+DELAYED)?(?:\s+INTO)?'
-				. '|UPDATE(?:\s+LOW_PRIORITY)?(?:\s+IGNORE)?'
-				. '|DELETE(?:\s+LOW_PRIORITY|\s+QUICK|\s+IGNORE)*(?:.+?FROM)?'
-				. ')\s+((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)/is', $query, $maybe ) ) {
-			return str_replace( '`', '', $maybe[1] );
-		}
-
-		// SHOW TABLE STATUS and SHOW TABLES WHERE Name = 'wp_posts'
-		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES).+WHERE\s+Name\s*=\s*("|\')((?:[0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)\\1/is', $query, $maybe ) ) {
-			return $maybe[2];
-		}
-
-		// SHOW TABLE STATUS LIKE and SHOW TABLES LIKE 'wp\_123\_%'
-		// This quoted LIKE operand seldom holds a full table name.
-		// It is usually a pattern for matching a prefix so we just
-		// strip the trailing % and unescape the _ to get 'wp_123_'
-		// which drop-ins can use for routing these SQL statements.
-		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES)\s+(?:WHERE\s+Name\s+)?LIKE\s*("|\')((?:[\\\\0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)%?\\1/is', $query, $maybe ) ) {
-			return str_replace( '\\_', '_', $maybe[2] );
-		}
-
-		// Big pattern for the rest of the table-related queries.
-		if ( preg_match( '/^\s*(?:'
-				. '(?:EXPLAIN\s+(?:EXTENDED\s+)?)?SELECT.*?\s+FROM'
-				. '|DESCRIBE|DESC|EXPLAIN|HANDLER'
-				. '|(?:LOCK|UNLOCK)\s+TABLE(?:S)?'
-				. '|(?:RENAME|OPTIMIZE|BACKUP|RESTORE|CHECK|CHECKSUM|ANALYZE|REPAIR).*\s+TABLE'
-				. '|TRUNCATE(?:\s+TABLE)?'
-				. '|CREATE(?:\s+TEMPORARY)?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?'
-				. '|ALTER(?:\s+IGNORE)?\s+TABLE'
-				. '|DROP\s+TABLE(?:\s+IF\s+EXISTS)?'
-				. '|CREATE(?:\s+\w+)?\s+INDEX.*\s+ON'
-				. '|DROP\s+INDEX.*\s+ON'
-				. '|LOAD\s+DATA.*INFILE.*INTO\s+TABLE'
-				. '|(?:GRANT|REVOKE).*ON\s+TABLE'
-				. '|SHOW\s+(?:.*FROM|.*TABLE)'
-				. ')\s+\(*\s*((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)\s*\)*/is', $query, $maybe ) ) {
-			return str_replace( '`', '', $maybe[1] );
-		}
-
-		return false;
 	}
 }
 

--- a/slow-bulk-update.php
+++ b/slow-bulk-update.php
@@ -2,6 +2,8 @@
 
 class SWPD_Slow_Bulk_Update extends SlowQueries {
 
+	public $debugger_name = 'slow bulk update';
+
 	public function __construct() {
 		if ( false === defined( 'SAVEQUERIES' ) ) {
 			define( 'SAVEQUERIES', true );
@@ -36,10 +38,6 @@ class SWPD_Slow_Bulk_Update extends SlowQueries {
 			$post_id = $post_ID = 0;
 		}
 		return $post_id;
-	}
-
-	public function log_sql_queries() {
-		swpd_log( 'slow bulk update', $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
 	}
 }
 

--- a/slow-post-save.php
+++ b/slow-post-save.php
@@ -2,6 +2,8 @@
 
 class SWPD_Slow_Post_Save extends SlowQueries {
 
+	public $debugger_name = 'slow post save';
+
 	public function __construct() {
 		if ( false === defined( 'SAVEQUERIES' ) ) {
 			define( 'SAVEQUERIES', true );
@@ -36,10 +38,6 @@ class SWPD_Slow_Post_Save extends SlowQueries {
 			$post_id = $post_ID = 0;
 		}
 		return $post_id;
-	}
-
-	public function log_sql_queries() {
-		swpd_log( 'slow save post', $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
 	}
 }
 

--- a/slow-post-save.php
+++ b/slow-post-save.php
@@ -24,7 +24,7 @@ class SWPD_Slow_Post_Save extends SlowQueries {
 
 	public function wp_redirect_filter( $location ) {
 		if ( true === $this->is_post_save() ) {
-			$this->log_sql_queries();
+			$this->log();
 		}
 		return $location;
 	}

--- a/slow-post-save.php
+++ b/slow-post-save.php
@@ -1,6 +1,6 @@
 <?php
 
-class SWPD_Slow_Post_Save {
+class SWPD_Slow_Post_Save extends SlowQueries {
 
 	public function __construct() {
 		if ( false === defined( 'SAVEQUERIES' ) ) {
@@ -27,126 +27,6 @@ class SWPD_Slow_Post_Save {
 		return $location;
 	}
 
-	public function render_sql_query_summary() {
-		global $wpdb;
-		$query_types = array();
-		$query_type_counts = array();
-		if ( is_array($wpdb->queries) ) {
-			$count = count($wpdb->queries);
-			for ( $i = 0; $i < $count; ++$i ) {
-				$query = array_key_exists( 'query', $wpdb->queries[$i] ) ? $wpdb->queries[$i]['query'] : $wpdb->queries[$i][0];
-				$query = trim( preg_replace( '#connection: dbh_.+$#','', $query ) );
-				$query = preg_replace( "#\s+#", ' ', $query );
-				$query = str_replace( '\"', '', $query );
-				$query = str_replace( "\'", '', $query );
-				$query = preg_replace( '#wp_\d+_#', 'wp_?_', $query );
-				$query = preg_replace( "#'[^']*'#", "'?'", $query );
-				$query = preg_replace( '#"[^"]*"#', "'?'", $query );
-				$query = preg_replace( "#in ?\([^)]*\)#i", 'in(?)', $query);
-				$query = preg_replace( "#= ?\d+ ?#", "= ? ", $query );
-				$query = preg_replace( "#\d+(, ?)?#", '?\1', $query);
-				$query = preg_replace( "#/\*.*\*/$#", '', $query );
-
-				$query = preg_replace( "#\s+#", ' ', $query );
-				if ( !isset( $query_types[$query] ) )
-					$query_types[$query] = 0;
-				if ( !isset( $query_type_counts[$query] ) )
-					$query_type_counts[$query] = 0;
-				$query_type_counts[$query]++;
-				$query_types[$query] += array_key_exists( 'elapsed', $wpdb->queries[$i] ) ? $wpdb->queries[$i]['elapsed'] : $wpdb->queries[$i][1];
-			}
-		}
-
-		arsort( $query_types );
-		$out = '';
-		$count = 0;
-		$max_time_len = 0;
-		foreach( $query_types as $q => $t ) {
-			$count++;
-				$max_time_len = max($max_time_len, strlen(sprintf('%0.2f', $t * 1000)));
-			$out .= sprintf(
-				"%s queries for %sms » %s\r\n",
-				str_pad( $query_type_counts[$q], 5, ' ', STR_PAD_LEFT ),
-				str_pad( sprintf('%0.2f', $t * 1000), $max_time_len, ' ', STR_PAD_LEFT ),
-				$q
-			);
-		}
-		return $out;
-	}
-
-	public function render_sql_queries() {
-		global $wpdb, $wp_object_cache, $timestart;
-
-		$out = '';
-		$total_time = 0;
-
-		if ( !empty($wpdb->queries) ) {
-
-			$counter = 0;
-
-			foreach ( $wpdb->queries as $q ) {
-				unset($query, $elapsed, $affected_rows, $host, $microtime, $debug, $dbhname, $dataset, $callback_result, $connection);
-				extract($q);
-
-				if ( false === isset( $query ) ) {
-					$query = $q[0];
-				}
-				if ( false === isset( $elapsed ) ){
-					$elapsed = $q[1];
-				}
-				if ( false === isset( $debug ) ) {
-					$debug = $q[2];
-				}
-
-				$total_time += $elapsed;
-				if ( ++$counter > 500 ) {
-					continue;
-				}
-
-				// ts is the absolute time at which each query was executed
-				if ( true === isset( $microtime ) ) {
-					$ts = explode( ' ', $microtime );
-					$ts = $ts[0] + $ts[1];
-				} else {
-					$ts = 0;
-				}
-
-				$query = esc_html($query);
-
-				// $dbhname, $host, $port, $name, $tcp, $elapsed
-				if ( isset($connection['elapsed']) ) {
-					$connected = "Connected {$connection['dbhname']} to {$connection['host']}:{$connection['port']} ({$connection['name']}) in ".sprintf('%0.2f', 1000*$connection['elapsed'])."ms";
-				} else if ( true === isset( $connection ) ) {
-					$connected = "Reused connection to {$connection['dbhname']} ({$connection['name']})";
-				} else {
-					$connected = '';
-				}
-
-				$debug = wp_strip_all_tags( $debug );
-				$out .= "$query \n $connected $debug #{$counter} (" . number_format(sprintf('%0.1f', $elapsed * 1000), 1, '.', ',') . "ms @ " . sprintf( '%0.2f', 1000 * ( $ts - $timestart ) ) . "ms)\n\n";
-			}
-		}
-
-		$num_queries = '';
-	    if ( $wpdb->num_queries ) {
-            $num_queries = 'Total Queries:' . number_format( $wpdb->num_queries ) . " | ";
-		}
-		$query_time = 'Total query time:' . number_format(sprintf('%0.1f', $total_time * 1000), 1) . "ms | ";
-		$memory_usage = 'Peak Memory Used:' . number_format( memory_get_peak_usage( ) ) . " bytes | ";
-		if ( true === property_exists( $wp_object_cache, 'time_total' ) ) {
-			$memcache_time = 'Total memcache query time:' .
-				number_format( sprintf( '%0.1f', $wp_object_cache->time_total * 1000 ), 1, '.', ',' ) . "ms \n\n";
-		} else {
-			$memcache_time = '';
-		}
-
-		$out = $num_queries . $query_time . $memory_usage . $memcache_time . $out;
-
-		$out = apply_filters( 'swpdb-render-sql-queries-output', $out );
-
-		return $out;
-	}
-
 	public function get_post_id() {
 		if ( isset( $_GET['post'] ) ) {
 			$post_id = $post_ID = (int) $_GET['post'];
@@ -160,68 +40,6 @@ class SWPD_Slow_Post_Save {
 
 	public function log_sql_queries() {
 		swpd_log( 'slow save post', $this->render_sql_queries() . 'Query Summary: ' . "\n" . $this->render_sql_query_summary(), null, array( 'Post' => $this->get_post_id() ), false );
-	}
-
-	/**
-	 * This is a copy of core's wpdb::get_table_from_query which is protected and can't otherwise be used
-	 *
-	 * @see https://core.trac.wordpress.org/browser/tags/4.7/src/wp-includes/wp-db.php#L3022
-	 */
-	public function get_table_from_query( $query ) {
-		// Remove characters that can legally trail the table name.
-		$query = rtrim( $query, ';/-#' );
-
-		// Allow (select...) union [...] style queries. Use the first query's table name.
-		$query = ltrim( $query, "\r\n\t (" );
-
-		// Strip everything between parentheses except nested selects.
-		$query = preg_replace( '/\((?!\s*select)[^(]*?\)/is', '()', $query );
-
-		// Quickly match most common queries.
-		if ( preg_match( '/^\s*(?:'
-				. 'SELECT.*?\s+FROM'
-				. '|INSERT(?:\s+LOW_PRIORITY|\s+DELAYED|\s+HIGH_PRIORITY)?(?:\s+IGNORE)?(?:\s+INTO)?'
-				. '|REPLACE(?:\s+LOW_PRIORITY|\s+DELAYED)?(?:\s+INTO)?'
-				. '|UPDATE(?:\s+LOW_PRIORITY)?(?:\s+IGNORE)?'
-				. '|DELETE(?:\s+LOW_PRIORITY|\s+QUICK|\s+IGNORE)*(?:.+?FROM)?'
-				. ')\s+((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)/is', $query, $maybe ) ) {
-			return str_replace( '`', '', $maybe[1] );
-		}
-
-		// SHOW TABLE STATUS and SHOW TABLES WHERE Name = 'wp_posts'
-		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES).+WHERE\s+Name\s*=\s*("|\')((?:[0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)\\1/is', $query, $maybe ) ) {
-			return $maybe[2];
-		}
-
-		// SHOW TABLE STATUS LIKE and SHOW TABLES LIKE 'wp\_123\_%'
-		// This quoted LIKE operand seldom holds a full table name.
-		// It is usually a pattern for matching a prefix so we just
-		// strip the trailing % and unescape the _ to get 'wp_123_'
-		// which drop-ins can use for routing these SQL statements.
-		if ( preg_match( '/^\s*SHOW\s+(?:TABLE\s+STATUS|(?:FULL\s+)?TABLES)\s+(?:WHERE\s+Name\s+)?LIKE\s*("|\')((?:[\\\\0-9a-zA-Z$_.-]|[\xC2-\xDF][\x80-\xBF])+)%?\\1/is', $query, $maybe ) ) {
-			return str_replace( '\\_', '_', $maybe[2] );
-		}
-
-		// Big pattern for the rest of the table-related queries.
-		if ( preg_match( '/^\s*(?:'
-				. '(?:EXPLAIN\s+(?:EXTENDED\s+)?)?SELECT.*?\s+FROM'
-				. '|DESCRIBE|DESC|EXPLAIN|HANDLER'
-				. '|(?:LOCK|UNLOCK)\s+TABLE(?:S)?'
-				. '|(?:RENAME|OPTIMIZE|BACKUP|RESTORE|CHECK|CHECKSUM|ANALYZE|REPAIR).*\s+TABLE'
-				. '|TRUNCATE(?:\s+TABLE)?'
-				. '|CREATE(?:\s+TEMPORARY)?\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?'
-				. '|ALTER(?:\s+IGNORE)?\s+TABLE'
-				. '|DROP\s+TABLE(?:\s+IF\s+EXISTS)?'
-				. '|CREATE(?:\s+\w+)?\s+INDEX.*\s+ON'
-				. '|DROP\s+INDEX.*\s+ON'
-				. '|LOAD\s+DATA.*INFILE.*INTO\s+TABLE'
-				. '|(?:GRANT|REVOKE).*ON\s+TABLE'
-				. '|SHOW\s+(?:.*FROM|.*TABLE)'
-				. ')\s+\(*\s*((?:[0-9a-zA-Z$_.`-]|[\xC2-\xDF][\x80-\xBF])+)\s*\)*/is', $query, $maybe ) ) {
-			return str_replace( '`', '', $maybe[1] );
-		}
-
-		return false;
 	}
 }
 

--- a/slow-post-save.php
+++ b/slow-post-save.php
@@ -28,17 +28,6 @@ class SWPD_Slow_Post_Save extends SlowQueries {
 		}
 		return $location;
 	}
-
-	public function get_post_id() {
-		if ( isset( $_GET['post'] ) ) {
-			$post_id = $post_ID = (int) $_GET['post'];
-		} elseif ( isset( $_POST['post_ID'] ) ) {
-			$post_id = $post_ID = (int) $_POST['post_ID'];
-		} else {
-			$post_id = $post_ID = 0;
-		}
-		return $post_id;
-	}
 }
 
 new SWPD_Slow_Post_Save();


### PR DESCRIPTION
There is a lot of common code in between two debuggers - slow post save, and slow bulk update.

The code of both debuggers can clearly benefit from a common parent class, which would do the heavy lifting of preparing data for DB queries, while the child classes would take care of the parts they do differently from each other.

This also helped identifying more unused code, which is being removed here.