### PR TITLE
Add do action debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,15 @@ By setting the second param of `swpd_apply_filter_debug` functin to `true` the o
   'priority' => 10,
 )
 ```
+
+### do_action
+
+A custom callback can be registered to run after each already registered callback to a hook, so the state of global variables and data can be examined.
+
+#### usage
+
+```
+wp shell --url=example.org
+wp> swpd_do_action_debug( 'widgets_init', function( $value, $idx, $the_, $priority ) { global $wp_widget_factory; if ( empty( $wp_widget_factory->widgets ) ) { var_dump( $the_ ); die; } } );
+wp> wp_widgets_init();
+```

--- a/do-action.php
+++ b/do-action.php
@@ -42,20 +42,6 @@ class SWPD_do_action {
 			return $value;
 	}
 
-	public function defined_in( $the_ ) {
-		$return = 'N/A';
-		// Handle function and closures.
-		if ( true === is_string( $the_['function'] ) || true === is_a( $the_['function'], '\Closure' ) ) {
-			$the_reflection = new ReflectionFunction( $the_['function'] );
-			$return = $the_reflection->getFileName() . '#L' . $the_reflection->getStartLine();
-		}
-		// Handle class' methods
-		if ( true === is_array( $the_['function'] ) ) {
-			$the_reflection = new ReflectionMethod( $the_['function'][0], $the_['function'][1] );
-			$return = $the_reflection->getFileName() . '#L' . $the_reflection->getStartLine();
-		}
-		return $return;
-	}
 }
 
 function swpd_do_action_debug( $action_to_debug, $callback ) {

--- a/do-action.php
+++ b/do-action.php
@@ -1,0 +1,72 @@
+<?php
+/**/
+class SWPD_do_action {
+
+	private $filter_to_debug = null;
+
+	private $callback = null;
+
+	private $swpd_filter_prev_value = null;
+
+	public function __construct( $filter, $callback ) {
+		$this->filter_to_debug = $filter;
+		$this->callback = $callback;
+		add_filter( 'all', array( $this, 'filter_all' ), 10, 2 );
+	}
+
+	public function filter_all( $action, $value = null ) {
+		if ( current_filter() === $this->filter_to_debug ) {
+			$this->add_debugging( $value );
+		}
+		return $value;
+	}
+
+	public function add_debugging( $value ) {
+		global $wp_filter;
+		if ( true === array_key_exists( $this->filter_to_debug, $wp_filter ) ) {
+			$filters = $wp_filter[$this->filter_to_debug]->callbacks;
+			$wp_filter[$this->filter_to_debug]->callbacks = array();
+			$i = 0;
+			foreach( $filters as $priority => $thes_ ) {
+				foreach( $thes_ as $idx => $the_ ) {
+					$wp_filter[$this->filter_to_debug]->callbacks[$priority][$idx] = $the_;
+					$wp_filter[$this->filter_to_debug]->callbacks[$priority][ _wp_filter_build_unique_id( $this->filter_to_debug, array( $this, 'debug' ), $priority ) . $i++ ] = array(
+						'function' => function( $value ) use ( $idx, $priority, $the_ ) { $this->debug( $value, $idx, $the_, $priority ); return $value; },
+						'accepted_args' => 1,
+					);
+				}
+			}
+		}
+	}
+
+	public function debug( $value, $idx, $the_, $priority ) {
+			($this->callback)( $value, $idx, $the_, $priority );
+			return $value;
+	}
+
+	public function defined_in( $the_ ) {
+		$return = 'N/A';
+		// Handle function and closures.
+		if ( true === is_string( $the_['function'] ) || true === is_a( $the_['function'], '\Closure' ) ) {
+			$the_reflection = new ReflectionFunction( $the_['function'] );
+			$return = $the_reflection->getFileName() . '#L' . $the_reflection->getStartLine();
+		}
+		// Handle class' methods
+		if ( true === is_array( $the_['function'] ) ) {
+			$the_reflection = new ReflectionMethod( $the_['function'][0], $the_['function'][1] );
+			$return = $the_reflection->getFileName() . '#L' . $the_reflection->getStartLine();
+		}
+		return $return;
+	}
+
+	public function log( $message, $data ) {
+		error_log( $message . ' ' . var_export( $data, true ) );
+		if ( true === defined( 'WP_CLI' ) && true === WP_CLI ) {
+			WP_CLI::Line( $message . ' ' . var_export( $data, true ) );
+		}
+	}
+}
+
+function swpd_do_action_debug( $filter_to_debug, $callback ) {
+	new SWPD_do_action( $filter_to_debug, $callback );
+}

--- a/do-action.php
+++ b/do-action.php
@@ -6,8 +6,6 @@ class SWPD_do_action {
 
 	private $callback = null;
 
-	private $swpd_filter_prev_value = null;
-
 	public function __construct( $filter, $callback ) {
 		$this->filter_to_debug = $filter;
 		$this->callback = $callback;

--- a/do-action.php
+++ b/do-action.php
@@ -56,13 +56,6 @@ class SWPD_do_action {
 		}
 		return $return;
 	}
-
-	public function log( $message, $data ) {
-		error_log( $message . ' ' . var_export( $data, true ) );
-		if ( true === defined( 'WP_CLI' ) && true === WP_CLI ) {
-			WP_CLI::Line( $message . ' ' . var_export( $data, true ) );
-		}
-	}
 }
 
 function swpd_do_action_debug( $action_to_debug, $callback ) {

--- a/do-action.php
+++ b/do-action.php
@@ -2,18 +2,18 @@
 /**/
 class SWPD_do_action {
 
-	private $filter_to_debug = null;
+	private $action_to_debug = null;
 
 	private $callback = null;
 
 	public function __construct( $filter, $callback ) {
-		$this->filter_to_debug = $filter;
+		$this->action_to_debug = $filter;
 		$this->callback = $callback;
 		add_filter( 'all', array( $this, 'filter_all' ), 10, 2 );
 	}
 
 	public function filter_all( $action, $value = null ) {
-		if ( current_filter() === $this->filter_to_debug ) {
+		if ( current_filter() === $this->action_to_debug ) {
 			$this->add_debugging( $value );
 		}
 		return $value;
@@ -21,14 +21,14 @@ class SWPD_do_action {
 
 	public function add_debugging( $value ) {
 		global $wp_filter;
-		if ( true === array_key_exists( $this->filter_to_debug, $wp_filter ) ) {
-			$filters = $wp_filter[$this->filter_to_debug]->callbacks;
-			$wp_filter[$this->filter_to_debug]->callbacks = array();
+		if ( true === array_key_exists( $this->action_to_debug, $wp_filter ) ) {
+			$filters = $wp_filter[$this->action_to_debug]->callbacks;
+			$wp_filter[$this->action_to_debug]->callbacks = array();
 			$i = 0;
 			foreach( $filters as $priority => $thes_ ) {
 				foreach( $thes_ as $idx => $the_ ) {
-					$wp_filter[$this->filter_to_debug]->callbacks[$priority][$idx] = $the_;
-					$wp_filter[$this->filter_to_debug]->callbacks[$priority][ _wp_filter_build_unique_id( $this->filter_to_debug, array( $this, 'debug' ), $priority ) . $i++ ] = array(
+					$wp_filter[$this->action_to_debug]->callbacks[$priority][$idx] = $the_;
+					$wp_filter[$this->action_to_debug]->callbacks[$priority][ _wp_filter_build_unique_id( $this->action_to_debug, array( $this, 'debug' ), $priority ) . $i++ ] = array(
 						'function' => function( $value ) use ( $idx, $priority, $the_ ) { $this->debug( $value, $idx, $the_, $priority ); return $value; },
 						'accepted_args' => 1,
 					);
@@ -65,6 +65,6 @@ class SWPD_do_action {
 	}
 }
 
-function swpd_do_action_debug( $filter_to_debug, $callback ) {
-	new SWPD_do_action( $filter_to_debug, $callback );
+function swpd_do_action_debug( $action_to_debug, $callback ) {
+	new SWPD_do_action( $action_to_debug, $callback );
 }

--- a/sandbox-wp-debugger.php
+++ b/sandbox-wp-debugger.php
@@ -17,6 +17,7 @@ require_once( SWPD_DIR_PATH . 'helper-functions.php' );
 
 require_once( SWPD_DIR_PATH . 'wp-redirect.php' );
 require_once( SWPD_DIR_PATH . 'apply-filters.php' );
+require_once( SWPD_DIR_PATH . 'do-action.php' );
 require_once( SWPD_DIR_PATH . 'batcache-debug.php' );
 
 if ( true === defined( 'WP_CLI' ) && WP_CLI ) {


### PR DESCRIPTION
Add a new feature to help with debugging the action callbacks.

Via `swpd_do_action_debug` function, one can hook a custom callback which is being run in between all already registered callbacks allowing developer to examine the state of global variables and other data.