### PR TITLE
PHP 8 Fatal fix for `join()`

### DIFF
--- a/batcache-debug.php
+++ b/batcache-debug.php
@@ -30,7 +30,7 @@ class SWPD_Batcache_Debug {
 		$message = array();
 
 		if ( false === empty( $_GET ) ) {
-			$message[] = sprintf( 'The request would bypass Batcache due to following query args: %s.', join( ', ', array_keys( $_GET ) ) );
+			$message[] = sprintf( 'The request would bypass Batcache due to following query args: %s.', implode( ', ', array_keys( $_GET ) ) );
 		}
 
 		// Compose diff of default and total list of ignored args.
@@ -49,10 +49,10 @@ class SWPD_Batcache_Debug {
 		}
 		
 		if ( false === empty( $client_specific_ignored_args ) ) {
-			$message[] = sprintf( 'Batcached is whitelisting following client specific params: %s', join( ', ', $client_specific_ignored_args ) );
+			$message[] = sprintf( 'Batcached is whitelisting following client specific params: %s', implode( ', ', $client_specific_ignored_args ) );
 		}
 		if ( false === empty( $globally_ignored_args ) ) {
-			$message[] = sprintf( 'Batcache is whitelisting following global/default params: %s', join( ',', $globally_ignored_args ) );
+			$message[] = sprintf( 'Batcache is whitelisting following global/default params: %s', implode( ',', $globally_ignored_args ) );
 		}
 
 		if ( false === empty( $message ) ) {

--- a/helper-functions.php
+++ b/helper-functions.php
@@ -18,5 +18,5 @@ function davidbinovec_debug_backtrace( $return = false ) {
 	if ( true === $return ) {
 		return $output;
 	}
-    error_log( join( $output, ' ' ) . ' ' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
+    error_log( implode( ' ', $output ) . ' ' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] );
 }

--- a/wp-redirect.php
+++ b/wp-redirect.php
@@ -106,7 +106,7 @@ class SWPD_WP_Redirect {
 			$slice++;	
 		}
 		$backtrace = array_slice( davidbinovec_debug_backtrace( true ), $slice );
-		swpd_log( $used_redirection_function, $message, $variables, $debug_data, str_replace( ', apply_filters(\'wp_redirect_status\'), WP_Hook->apply_filters, SWPD_WP_Redirect->report', '', join( $backtrace, ' ' ) ) );
+		swpd_log( $used_redirection_function, $message, $variables, $debug_data, str_replace( ', apply_filters(\'wp_redirect_status\'), WP_Hook->apply_filters, SWPD_WP_Redirect->report', '', implode( ' ', $backtrace ) ) );
 
 		return $status;
 	}


### PR DESCRIPTION
`Fatal error: Uncaught TypeError: array_slice(): Argument #2 ($offset) must be of type int, array given in /var/www/wp-content/mu-plugins/sandbox-wp-debugger/wp-redirect.php:108`

As of PHP 8, we can't pass the separator after the array. I'm also switching this out for `implode()` which is the primary name of the function.